### PR TITLE
取得してくるユーザー画像のサイズを修正

### DIFF
--- a/connpass_generate_list.sh
+++ b/connpass_generate_list.sh
@@ -20,7 +20,7 @@ for i in `seq 1 ${#CONNPASS_IDS[@]}`; do
 
     NAME="$(cat /tmp/user_request_cache.html | grep -A1 '<h2 class="title_2">' | tail -n 1 | sed -r 's/^[[:space:]]*|[[:space:]]*$//g')"
     TWITTER_ID="$(cat /tmp/user_request_cache.html | grep http://twitter.com/ | head -n 1 | grep -v connpass_jp | cut -d '"' -f 2 | cut -d "/" -f 4)"
-    IMG_URL="$(cat /tmp/user_request_cache.html | grep '<img src="https://media.connpass.com/thumbs/' | grep 'width="60" height="60"' | head -n 1  | cut -d '"' -f 2)"
+    IMG_URL="$(cat /tmp/user_request_cache.html | grep '<img src="https://media.connpass.com/thumbs/' | grep 'width="180" height="180"' | head -n 1  | cut -d '"' -f 2)"
 
     echo "$NAME,$TWITTER_ID,$IMG_URL"
 done > $OUTPUT_FILENAME


### PR DESCRIPTION
素晴らしいツールを作っていただき、ありがとうございます！
使ってみたのですが、取得したユーザーの画像が粗くなっているのが気になり、取得先を60px × 60pxの画像URLから180px × 180pxの画像URLに変えたところ鮮明な画像が取得できました。
もし、よければご確認よろしくお願いいたします！